### PR TITLE
feat: anonymize multiple files in one run

### DIFF
--- a/openvas/anonymizer/.gitignore
+++ b/openvas/anonymizer/.gitignore
@@ -1,2 +1,3 @@
 data/tlds.json
+anon-output/
 report-anonymized.xml

--- a/openvas/anonymizer/data/dns-keywords.txt
+++ b/openvas/anonymizer/data/dns-keywords.txt
@@ -43,6 +43,7 @@ glassfish
 grafana
 gw
 hadoop
+http
 idrac
 iis
 imap
@@ -74,7 +75,6 @@ oracle
 pages
 paloalto
 plone
-pop
 portal
 postgres
 private


### PR DESCRIPTION
anonymizing multiple files in one run is necessary to avoid resetting the anonymization counters across files.

this commit also adds the functionality to assume that ccTLDs do not have subdomains like .com and .org (which applies, e.g., to ufmg.br).